### PR TITLE
Multiple bug fixes

### DIFF
--- a/Info.lua
+++ b/Info.lua
@@ -5,22 +5,22 @@
 g_PluginInfo =
 {
 	Name = "DisguiseCraft",
-	Version = "0.1",
-	Description = [[Plugin for Cuberite that allows you to disguise as a mob. It's a little different from similar Bukkit plugins, due to Cuberite's limitations.]],
+	Version = "1",
+	Description = [[Plugin for Cuberite that allows you to disguise as an entity.]],
 
 	Commands =
 	{
 		["/disguise"] =
 		{
 			Permission = "disguisecraft.disguise",
-			HelpString = "Allows you to disguise as a mob.",
+			HelpString = "Disguises you as an entity",
 			Handler = HandleDisguiseCommand,
 			Alias = { "/d", "/dis", }
 		},
 		["/undisguise"] =
 		{
 			Permission =  "disguisecraft.undisguise",
-			HelpString =  "Remove your mob disguise.",
+			HelpString =  "Removes your entity disguise",
 			Handler =  HandleUnDisguiseCommand,
 			Alias = { "/ud", "/undis", }
 		},

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-DisguiseCraft
-=============
+Plugin for Cuberite that allows you to disguise as an entity.
 
-Plugin for Cuberite that allows you to disguise as a mob. It's a little different from similar Bukkit plugins, due to Cuberite's limitations.
+# Commands
 
-###Commands
+### General
+| Command | Permission | Description |
+| ------- | ---------- | ----------- |
+|/disguise | disguisecraft.disguise | Disguises you as an entity|
+|/undisguise | disguisecraft.undisguise | Removes your entity disguise|
 
-| Command | Aliases | Permission | Description |
-| ------- | ------- | ---------- | ----------- |
-|/disguise | /dis, /d | disguisecraft.disguise | Allows you to disguise as a mob.|
-|/undisguise | /undis, /ud | disguisecraft.undisguise | Remove your mob disguise.|
+
+
+# Permissions
+| Permissions | Description | Commands | Recommended groups |
+| ----------- | ----------- | -------- | ------------------ |
+| disguisecraft.disguise |  | `/disguise` |  |
+| disguisecraft.undisguise |  | `/undisguise` |  |

--- a/commands.lua
+++ b/commands.lua
@@ -1,56 +1,96 @@
 function HandleDisguiseCommand(Split, Player)
 	if Split[2] == nil then
 		Player:SendMessageInfo("Usage: "..Split[1].." <mobtype[:baby]> [customname ...]")
-		Player:SendMessageInfo("Available types: bat, blaze, cavespider, chicken, cow, creeper, enderdragon, enderman, ghast, giant, guardian, horse, irongolem, magmacube, mooshroom, ocelot, pig, rabbit, sheep, silverfish, skeleton, slime, snowgolem, spider, squid, villager, witch, wither, wolf, zombie, zombiepigman")
+		Player:SendMessageInfo("Available types: arrow, bat, blaze, boat, cavespider, chicken, cow, creeper, egg, enderdragon, enderman, enderpearl, expbottle, fireball, firecharge, ghast, giant, guardian, horse, irongolem, magmacube, minecart, minecartchest, minecartfurnace, minecarthopper, minecarttnt, mooshroom, ocelot, pig, rabbit, sheep, silverfish, skeleton, slime, snowball, snowgolem, spider, splashpotion, squid, villager, witch, wither, witherskull, wolf, zombie, zombiepigman")
 	else
 		local IsBaby = false
-		local MobString = Split[2]
-		
-		if string.find(MobString, ":") then
-			MobString, data = string.match(MobString, "(%w+):(%w+)")
+		local EntityString = string.lower(Split[2])
+
+		if string.find(EntityString, ":") then
+			EntityString, data = string.match(EntityString, "(%w+):(%w+)")
 			if data == "baby" then
 				IsBaby = true
 			end
 		end
 
-		local MobType = cMonster:StringToMobType(MobString)
+		local MobType = cMonster:StringToMobType(EntityString)
+		local World = Player:GetWorld()
+		local X = Player:GetPosX() + 1.1
+		local Y = Player:GetPosY()
+		local Z = Player:GetPosZ() + 1.1
+		local Origin = Player:GetEquippedItem()
+		local Speed = Vector3d():Move(0, 0, 0)
 
-		if MobType == mtInvalidType then
-			Player:SendMessageFailure("That disguise type was not recognized")
+		if MobType ~= mtInvalidType or EntityString == "arrow" or EntityString == "boat" or EntityString == "egg" or EntityString == "enderpearl" or EntityString == "expbottle" or EntityString == "fireball" or EntityString == "firecharge" or EntityString == "minecart" or EntityString == "minecartchest" or EntityString == "minecartfurnace" or EntityString == "minecarthopper" or EntityString == "minecarttnt" or EntityString == "snowball" or EntityString == "splashpotion" or EntityString == "witherskull" then 
+			if DisguiseFor[Player:GetUUID()] ~= nil then
+				Player:GetWorld():DoWithEntityByID(DisguiseFor[Player:GetUUID()], cEntity.Destroy)
+			end
+		end
+
+		if EntityString == "arrow" then
+			DisguiseFor[Player:GetUUID()] = World:CreateProjectile(X, Y, Z, 60, Player, Origin, Speed)
+		elseif EntityString == "boat" then
+			DisguiseFor[Player:GetUUID()] = World:SpawnBoat(X + 0.1, Y, Z + 0.1)
+		elseif EntityString == "egg" then
+			DisguiseFor[Player:GetUUID()] = World:CreateProjectile(X, Y, Z, 62, Player, Origin, Speed)
+		elseif EntityString == "enderpearl" then
+			DisguiseFor[Player:GetUUID()] = World:CreateProjectile(X, Y, Z, 65, Player, Origin, Speed)
+		elseif EntityString == "expbottle" then
+			DisguiseFor[Player:GetUUID()] = World:CreateProjectile(X, Y, Z, 75, Player, Origin, Speed)
+		elseif EntityString == "fireball" then
+			DisguiseFor[Player:GetUUID()] = World:CreateProjectile(X, Y, Z, 63, Player, Origin, Speed)
+		elseif EntityString == "firecharge" then
+			DisguiseFor[Player:GetUUID()] = World:CreateProjectile(X, Y, Z, 64, Player, Origin, Speed)
+		elseif EntityString == "giant" or EntityString == "ghast" then
+			DisguiseFor[Player:GetUUID()] = World:SpawnMob(X + 1.5, Y, Z + 1.5, MobType, IsBaby)
+		elseif EntityString == "minecart" then
+			DisguiseFor[Player:GetUUID()] = World:SpawnMinecart(X, Y, Z, 328)
+		elseif EntityString == "minecartchest" then
+			DisguiseFor[Player:GetUUID()] = World:SpawnMinecart(X, Y, Z, 342)
+		elseif EntityString == "minecartfurnace" then
+			DisguiseFor[Player:GetUUID()] = World:SpawnMinecart(X, Y, Z, 343)
+		elseif EntityString == "minecarthopper" then
+			DisguiseFor[Player:GetUUID()] = World:SpawnMinecart(X, Y, Z, 408)
+		elseif EntityString == "minecarttnt" then
+			DisguiseFor[Player:GetUUID()] = World:SpawnMinecart(X, Y, Z, 407)
+		elseif EntityString == "snowball" then
+			DisguiseFor[Player:GetUUID()] = World:CreateProjectile(X, Y, Z, 61, Player, Origin, Speed)
+		elseif EntityString == "splashpotion" then
+			DisguiseFor[Player:GetUUID()] = World:CreateProjectile(X, Y, Z, 73, Player, Origin, Speed)
+		elseif EntityString == "witherskull" then
+			DisguiseFor[Player:GetUUID()] = World:CreateProjectile(X, Y, Z, 66, Player, Origin, Speed)
+		elseif MobType ~= mtInvalidType then
+			DisguiseFor[Player:GetUUID()] = World:SpawnMob(X, Y, Z, MobType, IsBaby)
 		else
-			if mobid[Player:GetName()] ~= nil then
-				HandleUnDisguiseCommand(Split, Player)
-			end    
-			Player:SetVisible(false)
-			mobid[Player:GetName()] = Player:GetWorld():SpawnMob(Player:GetPosX(), Player:GetPosY(), Player:GetPosZ(), MobType, IsBaby)
+			Player:SendMessageFailure("Invalid disguise type \"" .. Split[2] .. "\"")
+			return true
+		end
 
+		if MobType ~= mtInvalidType then
 			Player:GetWorld():DoWithEntityByID(
-				mobid[Player:GetName()],
-				function(MobFunctions)
-					SetMobFunction = tolua.cast(MobFunctions, "cMonster")
-					SetMobFunction:SetCustomName(table.concat( Split , " " , 3 ))
+				DisguiseFor[Player:GetUUID()],
+				function(Entity)
+					Entity:SetCustomName(table.concat( Split , " " , 3 ))
 				end
 			)
+		end
 
-			StartsWith = string.sub(MobString, 1, 1)
-			if StartsWith == "e" or StartsWith == "i" or StartsWith == "o" or StartsWith == "E" or StartsWith == "I" or StartsWith == "O" then
-				Player:SendMessageSuccess("You have been disguised as an "..string.lower(MobString))
-			else
-				Player:SendMessageSuccess("You have been disguised as a "..string.lower(MobString))
-			end
+		local StartsWith = string.sub(EntityString, 1, 1)
+		if StartsWith == "e" or StartsWith == "i" or StartsWith == "o" then
+			Player:SendMessageSuccess("You have been disguised as an " .. EntityString)
+		else
+			Player:SendMessageSuccess("You have been disguised as a " .. EntityString)
 		end
 	end
 	return true
 end
 
 function HandleUnDisguiseCommand(Split, Player)
-	if mobid[Player:GetName()] ~= nil then
-		Player:SetVisible(true)
-		Player:GetWorld():DoWithEntityByID(mobid[Player:GetName()], cEntity.Destroy)
-		mobid[Player:GetName()] = nil
+	if DisguiseFor[Player:GetUUID()] ~= nil then
+		DestroyDisguise(Player)
 		Player:SendMessageSuccess("You have been undisguised")
 	else   
-		Player:SendMessageFailure("You're not disguised") 
+		Player:SendMessageFailure("You are not disguised") 
 	end    
 	return true
 end

--- a/main.lua
+++ b/main.lua
@@ -1,30 +1,37 @@
-mobid = {}
+DisguiseFor = {}
 
 function Initialize(Plugin)
-        
 	dofile(cPluginManager:GetPluginsPath() .. "/InfoReg.lua")
 
 	Plugin:SetName(g_PluginInfo.Name)
 	Plugin:SetVersion(g_PluginInfo.Version)
 
 	cPluginManager:AddHook(cPluginManager.HOOK_WORLD_TICK, OnWorldTick)
+	cPluginManager:AddHook(cPluginManager.HOOK_ENTITY_CHANGING_WORLD, OnEntityChangingWorld)
 	cPluginManager:AddHook(cPluginManager.HOOK_TAKE_DAMAGE, OnTakeDamage)
+	cPluginManager:AddHook(cPluginManager.HOOK_PLAYER_RIGHT_CLICKING_ENTITY, OnPlayerRightClickingEntity)
 	cPluginManager:AddHook(cPluginManager.HOOK_PLAYER_SPAWNED, OnPlayerSpawned)
 	cPluginManager:AddHook(cPluginManager.HOOK_PLAYER_DESTROYED, OnPlayerDestroyed)
 
-	RegisterPluginInfoCommands();
+	RegisterPluginInfoCommands()
 
-	LOG("Initialized " .. Plugin:GetName() .. " v." .. Plugin:GetVersion())
+	LOG("Initialised " .. Plugin:GetName() .. " v." .. Plugin:GetVersion())
 	return true
+end
+
+function DestroyDisguise(Player)
+	Player:GetWorld():DoWithEntityByID(DisguiseFor[Player:GetUUID()], cEntity.Destroy)
+	DisguiseFor[Player:GetUUID()] = nil
+	Player:SetVisible(true)
 end
 
 function OnDisable()
 	local RemoveMob = function(Player)
-		if mobid[Player:GetName()] ~= nil then
-			Player:GetWorld():DoWithEntityByID(mobid[Player:GetName()], cEntity.Destroy)
-			Player:SendMessageWarning("You've been undisguised due to server reload")
-			Player:SetVisible(true)
+		if DisguiseFor[Player:GetUUID()] ~= nil then
+			DestroyDisguise(Player)
+			Player:SendMessageInfo("You have been undisguised due to server reload")
 		end
 	end    
 	cRoot:Get():ForEachPlayer(RemoveMob)
+	LOG("Disabled " .. cPluginManager:GetCurrentPlugin():GetName() .. "!")
 end


### PR DESCRIPTION
- You can disguise as boats, minecarts and projectiles
- When a player moves to another world, the entity also moves to the new world
- The player is now invulnerable and invisible constantly while disguised
- Players can no longer right-click their disguises, e.g. if the entity has a saddle or the entity is a boat
- Cleaned up code, removed unnecessary tolua casts

Fixes #8, #10 (and #2)
